### PR TITLE
#49 게시글 사진 삭제 메소드

### DIFF
--- a/src/main/java/com/sparta/cucumber/controller/ArticleRestController.java
+++ b/src/main/java/com/sparta/cucumber/controller/ArticleRestController.java
@@ -70,6 +70,7 @@ public class ArticleRestController {
     public ResponseEntity<Long> removeArticle(@PathVariable("userId") Long userId,
                                               @PathVariable("id") Long articleId) {
         Long id = articleService.removeArticle(userId, articleId);
+        s3Uploader.deleteImage(articleId);
         return ResponseEntity.ok().body(id);
     }
 

--- a/src/main/java/com/sparta/cucumber/service/S3Uploader.java
+++ b/src/main/java/com/sparta/cucumber/service/S3Uploader.java
@@ -4,6 +4,8 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.sparta.cucumber.models.Article;
+import com.sparta.cucumber.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +25,7 @@ import java.util.Optional;
 public class S3Uploader {
 
     private final AmazonS3Client amazonS3Client;
+    private final ArticleRepository articleRepository;
 
     @Value("${cloud.aws.s3.bucket}")
     public String bucket;
@@ -73,8 +76,11 @@ public class S3Uploader {
         return Optional.empty();
     }
 
-    public void deleteImage(String imageName){
-        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, "Article/" + imageName);
+    public void deleteImage(Long articleId){
+        Article article = articleRepository.findById(articleId).orElseThrow(
+                () -> new NullPointerException("해당 게시글이 존재하지 않습니다")
+        );
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, "Article/" + article.getImageName());
         amazonS3Client.deleteObject(deleteObjectRequest);
 
     }

--- a/src/main/java/com/sparta/cucumber/service/S3Uploader.java
+++ b/src/main/java/com/sparta/cucumber/service/S3Uploader.java
@@ -2,6 +2,7 @@ package com.sparta.cucumber.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,5 +71,11 @@ public class S3Uploader {
         }
 
         return Optional.empty();
+    }
+
+    public void deleteImage(String imageName){
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, "Article/" + imageName);
+        amazonS3Client.deleteObject(deleteObjectRequest);
+
     }
 }


### PR DESCRIPTION
<!--
title must use prefix like this
feat: new feature
fix: bugfix
docs: document changes
style: changes except codes(like indent, import..)
refactor: refactoring
test: test code
chore: about build or deploy(not changes code)
-->

## Changes

## Reason for change

## Detailed Description
S3에 저장되어있는 사진이 삭제되는 메소드 추가하였습니다


## mention
@AndrewDongminYoo

Resolves: #49
See also: #IssueNum.  